### PR TITLE
[FEATURE] 로그인/회원가입 api 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-router-dom": "^7.1.1",
     "recharts": "^2.15.1",
     "sass": "^1.83.4",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.75.7
         version: 5.75.7(react@18.3.1)
-      '@tanstack/react-query-devtools':
-        specifier: ^5.75.7
-        version: 5.75.7(@tanstack/react-query@5.75.7(react@18.3.1))(react@18.3.1)
       async-mutex:
         specifier: ^0.5.0
         version: 0.5.0
@@ -77,6 +74,9 @@ importers:
       zod:
         specifier: ^3.24.2
         version: 3.24.2
+      zustand:
+        specifier: ^5.0.6
+        version: 5.0.6(@types/react@18.3.18)(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.17.0
@@ -84,6 +84,9 @@ importers:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.74.7
         version: 5.74.7(eslint@9.17.0)(typescript@5.6.3)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.75.7
+        version: 5.75.7(@tanstack/react-query@5.75.7(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^22.13.14
         version: 22.13.14
@@ -1884,6 +1887,24 @@ packages:
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
+  zustand@5.0.6:
+    resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -3499,3 +3520,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.24.2: {}
+
+  zustand@5.0.6(@types/react@18.3.18)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.18
+      react: 18.3.1

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -1,14 +1,19 @@
 import { Link, NavLink } from 'react-router-dom';
-import styles from './header.module.scss';
-import { headerNavItems } from '@/lib/constants/navItems';
-import SearchForm from './SearchForm';
-import LanguageButton from './LanguageButton';
+
 import Button from '../button/Button';
+import LanguageButton from './LanguageButton';
 import { title as Logo } from '@/lib/constants/serviceName';
+import SearchForm from './SearchForm';
+import { headerNavItems } from '@/lib/constants/navItems';
+import styles from './header.module.scss';
+import { useAuthStore } from '@/lib/stores/useAuthStore';
 import { useTranslation } from 'react-i18next';
 
 export default function Header() {
   const { t } = useTranslation('common');
+  const isLoggedIn = useAuthStore(state => state.isLoggedIn);
+  const logout = useAuthStore(state => state.logout);
+  const userImgUrl = useAuthStore(state => state.profileImageUrl);
 
   return (
     <div className={styles.header}>
@@ -32,12 +37,25 @@ export default function Header() {
       <div className={styles.right}>
         <SearchForm />
         <LanguageButton />
-        <Link to='/login'>
-          <Button variant='outline'>{t('login')}</Button>
-        </Link>
-        <Link to='/register'>
-          <Button>{t('signUp')}</Button>
-        </Link>
+        {!isLoggedIn ? (
+          <>
+            <Link to='/login'>
+              <Button variant='outline'>{t('login')}</Button>
+            </Link>
+            <Link to='/register'>
+              <Button>{t('signUp')}</Button>
+            </Link>
+          </>
+        ) : (
+          <>
+            <Link to='/profile' className={styles.profileBox}>
+              <img src={userImgUrl} alt='프로필' />
+            </Link>
+            <Button variant='outline' onClick={() => logout()}>
+              {t('로그아웃')}
+            </Button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/common/header/header.module.scss
+++ b/src/components/common/header/header.module.scss
@@ -37,6 +37,18 @@
   gap: 1.5rem;
   justify-content: flex-end;
   align-items: center;
+  .profileBox {
+    width: 3rem;
+    height: 3rem;
+    border: 1px solid black;
+    border-radius: 50%;
+    img {
+      width: 100%;
+      height: auto;
+      border-radius: 50%;
+      object-fit: cover;
+    }
+  }
 
   @media (max-width: 1280px) {
     gap: 1rem;

--- a/src/components/register/IsCompanyUser.CheckBox.tsx
+++ b/src/components/register/IsCompanyUser.CheckBox.tsx
@@ -1,0 +1,21 @@
+import { Check } from 'lucide-react';
+import styles from './isCompanyUserCheckBox.module.scss';
+
+type IsCompanyUserCheckBoxProps = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+export default function IsCompanyUserCheckBox({
+  checked,
+  onChange,
+}: IsCompanyUserCheckBoxProps) {
+  return (
+    <div className={styles.container} onClick={() => onChange(!checked)}>
+      <Check
+        className={`${checked === true ? styles.checked : styles.unchecked}`}
+      />
+      <div>기업 사용자인가요 ?</div>
+    </div>
+  );
+}

--- a/src/components/register/isCompanyUserCheckBox.module.scss
+++ b/src/components/register/isCompanyUserCheckBox.module.scss
@@ -1,0 +1,23 @@
+.container {
+  padding: 0.8rem 1rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+  user-select: none;
+  gap: 1rem;
+  div {
+    font-weight: bold;
+    font-size: 1.2em;
+  }
+}
+
+.checked {
+  border-color: var(--color-green-300);
+  color: #0f5132;
+}
+
+.unchecked {
+  border-color: #ccc;
+  color: var(--color-gray-200);
+}

--- a/src/lib/apis/mutations/useGetMyInfo.ts
+++ b/src/lib/apis/mutations/useGetMyInfo.ts
@@ -1,0 +1,34 @@
+import { END_POINTS } from '@/lib/constants/routes';
+import { fetcher } from '@/lib/fetcher';
+import { useAuthStore } from '@/lib/stores/useAuthStore';
+import { useQuery } from '@tanstack/react-query';
+
+export interface MyInfoResponse {
+  name: string;
+  type: 'FOREIGNER' | 'COMPANY' | 'ADMIN' | 'NONE';
+  phoneNumber: string;
+  email: string;
+  profile_image_url: string;
+}
+
+export const getMyInfo = async (): Promise<MyInfoResponse> => {
+  const response = await fetcher.get(END_POINTS.MY_INFO);
+  return response.data;
+};
+
+const useGetMyInfo = () => {
+  const isLoggedIn = useAuthStore(state => state.isLoggedIn);
+  return {
+    ...useQuery({
+      queryKey: ['myInfo'],
+      queryFn: getMyInfo,
+      staleTime: 1000 * 60 * 5,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      enabled: isLoggedIn,
+      retry: false,
+    }),
+  };
+};
+
+export default useGetMyInfo;

--- a/src/lib/apis/mutations/usePoseForeignerSignup.ts
+++ b/src/lib/apis/mutations/usePoseForeignerSignup.ts
@@ -1,6 +1,6 @@
 import { END_POINTS } from '@/lib/constants/routes';
-import { fetcher } from '@/lib/fetcher';
 import { RegisterValues } from '@/lib/schemas/registerSchema';
+import { fetcher } from '@/lib/fetcher';
 import { useMutation } from '@tanstack/react-query';
 
 interface PostForeignerSignupRequest
@@ -10,6 +10,7 @@ const postForeignerSignup = async (body: PostForeignerSignupRequest) => {
   return fetcher.post<PostForeignerSignupRequest>(
     END_POINTS.FOREIGNER_SIGN_UP,
     body,
+    { skipAuth: true },
   );
 };
 

--- a/src/lib/apis/mutations/usePostCompanyUserSignup.ts
+++ b/src/lib/apis/mutations/usePostCompanyUserSignup.ts
@@ -1,0 +1,31 @@
+import { END_POINTS } from '@/lib/constants/routes';
+import { RegisterValues } from '@/lib/schemas/registerSchema';
+import { fetcher } from '@/lib/fetcher';
+import { useMutation } from '@tanstack/react-query';
+
+interface PostCompanyUserSignupRequest
+  extends Omit<RegisterValues, 'passwordConfirm'> {}
+
+const postCompanyUserSignup = async (body: PostCompanyUserSignupRequest) => {
+  return fetcher.post<PostCompanyUserSignupRequest>(
+    END_POINTS.COMPANY_SIGN_UP,
+    body,
+    { skipAuth: true },
+  );
+};
+
+const usePostCompanyUserSignup = () =>
+  useMutation({
+    mutationFn: postCompanyUserSignup,
+    mutationKey: ['companySignup'],
+    onSuccess: data => {
+      console.log('Post successful:', data);
+      return data;
+    },
+    onError: error => {
+      console.error('Post failed:', error);
+      return error;
+    },
+  });
+
+export default usePostCompanyUserSignup;

--- a/src/lib/apis/mutations/usePostSignin.ts
+++ b/src/lib/apis/mutations/usePostSignin.ts
@@ -1,10 +1,24 @@
+import { CustomAxiosRequestConfig, instance } from '@/lib/fetcher';
+
 import { END_POINTS } from '@/lib/constants/routes';
-import { fetcher } from '@/lib/fetcher';
+import { LOCAL_STORAGE } from '@/lib/constants';
 import { LoginValues } from '@/lib/schemas/loginSchema';
 import { useMutation } from '@tanstack/react-query';
 
 const postSignin = async (body: LoginValues) => {
-  return fetcher.post<LoginValues>(END_POINTS.SIGN_IN, body);
+  const config: CustomAxiosRequestConfig = {
+    skipAuth: true,
+    withCredentials: true,
+  };
+
+  const response = await instance.post(END_POINTS.SIGN_IN, body, config);
+
+  const accessToken = response.headers['authorization'];
+  if (accessToken) {
+    localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, accessToken);
+  }
+
+  return response.data;
 };
 
 const usePostSignin = () =>
@@ -13,12 +27,10 @@ const usePostSignin = () =>
     mutationKey: ['signin'],
     onSuccess: data => {
       console.log('Post successful:', data);
-
       return data;
     },
     onError: error => {
       console.error('Post failed:', error);
-
       return error;
     },
   });

--- a/src/lib/apis/mutations/usePostSignin.ts
+++ b/src/lib/apis/mutations/usePostSignin.ts
@@ -13,9 +13,11 @@ const postSignin = async (body: LoginValues) => {
 
   const response = await instance.post(END_POINTS.SIGN_IN, body, config);
 
-  const accessToken = response.headers['authorization'];
-  if (accessToken) {
-    localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, accessToken);
+  const rawAuthorization = response.headers['authorization'];
+
+  if (rawAuthorization && rawAuthorization.startsWith('Bearer ')) {
+    const token = rawAuthorization.replace('Bearer ', '');
+    localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, token);
   }
 
   return response.data;

--- a/src/lib/constants/routes.ts
+++ b/src/lib/constants/routes.ts
@@ -42,4 +42,5 @@ export const END_POINTS = {
   SIGN_IN: '/api/v1/members/sign-in',
   SIGN_OUT: '/api/v1/members/sign-out',
   REFRESH: '/token/refresh',
+  MY_INFO: '/api/v1/members/me',
 };

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -13,7 +13,7 @@ import camelcaseKeys from 'camelcase-keys';
 import { refreshAccessToken } from './refreshAccessToken';
 
 // 커스텀 설정 타입 정의
-interface CustomAxiosRequestConfig extends AxiosRequestConfig {
+export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
   skipAuth?: boolean;
 }
 
@@ -127,8 +127,11 @@ async function resultify<T>(promise: Promise<AxiosResponse<T>>): Promise<T> {
 export const fetcher = {
   get: <T>(url: string, config?: CustomAxiosRequestConfig) =>
     resultify<T>(instance.get<T>(url, config)),
-  post: <T>(url: string, data?: unknown, config?: CustomAxiosRequestConfig) =>
-    resultify<T>(instance.post<T>(url, data, config)),
+  post: <T>(
+    url: string,
+    data?: unknown,
+    config?: CustomAxiosRequestConfig & { extractAccessToken?: boolean },
+  ) => resultify<T>(instance.post<T>(url, data, config)),
   put: <T>(url: string, data?: unknown, config?: CustomAxiosRequestConfig) =>
     resultify<T>(instance.put<T>(url, data, config)),
   patch: <T>(url: string, data?: unknown, config?: CustomAxiosRequestConfig) =>

--- a/src/lib/hooks/useAuth.ts
+++ b/src/lib/hooks/useAuth.ts
@@ -1,0 +1,37 @@
+import { LoginValues } from '@/lib/schemas/loginSchema';
+import { getMyInfo } from '@/lib/apis/mutations/useGetMyInfo';
+import { useAuthStore } from '@/lib/stores/useAuthStore';
+import usePostSignin from '@/lib/apis/mutations/usePostSignin';
+
+export const useAuth = () => {
+  const {
+    login,
+    setName,
+    setType,
+    setPhoneNumber,
+    setEmail,
+    setProfileImageUrl,
+  } = useAuthStore();
+
+  const signinMutation = usePostSignin();
+
+  const loginAndFetchUser = async (values: LoginValues) => {
+    await signinMutation.mutateAsync(values);
+    login();
+
+    const response = await getMyInfo();
+    const user = response;
+    console.log('[useAuth] User Info:', user);
+
+    setName(user.name);
+    setType(user.type);
+    setPhoneNumber(user.phoneNumber);
+    setEmail(user.email);
+    setProfileImageUrl(user.profile_image_url);
+  };
+
+  return {
+    loginAndFetchUser,
+    ...signinMutation,
+  };
+};

--- a/src/lib/schemas/registerSchema.ts
+++ b/src/lib/schemas/registerSchema.ts
@@ -1,6 +1,6 @@
-import { z } from 'zod';
 import { ERROR_MSG } from './error';
 import { REGEX } from './regex';
+import { z } from 'zod';
 
 export const registerSchema = z
   .object({
@@ -15,7 +15,8 @@ export const registerSchema = z
       .string()
       .min(1, ERROR_MSG.required)
       .max(30, ERROR_MSG.exceed.thirty),
-    gender: z.string().min(1, ERROR_MSG.required),
+    gender: z.string().min(1, ERROR_MSG.required).toUpperCase(),
+    profileImageUrl: z.string().default('default'),
     phoneNumber: z
       .string()
       .min(1, ERROR_MSG.required)

--- a/src/lib/schemas/userProfileEditSchema.ts
+++ b/src/lib/schemas/userProfileEditSchema.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
 import { ERROR_MSG } from './error';
+import { z } from 'zod';
 
 export const userProfileEditSchema = z.object({
   phoneNumber: z
@@ -15,10 +15,18 @@ export const userProfileEditSchema = z.object({
   zipcode: z.string().min(1, { message: ERROR_MSG.required }),
 });
 
-export type LoginValues = z.infer<typeof userProfileEditSchema>;
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, { message: ERROR_MSG.required })
+    .email({ message: ERROR_MSG.email }),
+  password: z.string().min(1, { message: ERROR_MSG.required }),
+});
+
+export type LoginValues = z.infer<typeof loginSchema>;
 
 export const validateLogin = (formData: FormData) => {
   const formValues = Object.fromEntries(formData.entries());
 
-  return userProfileEditSchema.safeParse(formValues);
+  return loginSchema.safeParse(formValues);
 };

--- a/src/lib/stores/useAuthStore.ts
+++ b/src/lib/stores/useAuthStore.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type UserType = 'NONE' | 'FOREIGNER' | 'COMPANY' | 'ADMIN';
+
+interface AuthStateValues {
+  isLoggedIn: boolean;
+  name: string;
+  type: UserType;
+  phoneNumber: string;
+  email: string;
+  profileImageUrl: string;
+}
+
+interface AuthStateActions {
+  login: () => void;
+  logout: () => void;
+  setName: (name: string) => void;
+  setType: (type: UserType) => void;
+  setPhoneNumber: (phoneNumber: string) => void;
+  setEmail: (email: string) => void;
+  setProfileImageUrl: (url: string) => void;
+}
+
+export const useAuthStore = create<AuthStateValues & AuthStateActions>()(
+  persist(
+    set => ({
+      isLoggedIn: false,
+      name: '',
+      type: 'NONE',
+      phoneNumber: '',
+      email: '',
+      profileImageUrl: '',
+
+      login: () => set({ isLoggedIn: true }),
+      logout: () =>
+        set({
+          isLoggedIn: false,
+          name: '',
+          type: 'NONE',
+          phoneNumber: '',
+          email: '',
+          profileImageUrl: '',
+        }),
+
+      setName: name => {
+        console.log('[setName]', name);
+        set({ name });
+      },
+      setType: type => set({ type }),
+      setPhoneNumber: phoneNumber => set({ phoneNumber }),
+      setEmail: email => set({ email }),
+      setProfileImageUrl: url => set({ profileImageUrl: url }),
+    }),
+    {
+      name: 'auth-storage',
+      partialize: state => ({
+        isLoggedIn: state.isLoggedIn,
+        name: state.name,
+        type: state.type,
+        phoneNumber: state.phoneNumber,
+        email: state.email,
+        profileImageUrl: state.profileImageUrl,
+      }),
+    },
+  ),
+);

--- a/src/pages/login/Page.tsx
+++ b/src/pages/login/Page.tsx
@@ -1,11 +1,12 @@
-import { Link, useNavigate } from 'react-router-dom';
-import styles from './page.module.scss';
 import { FormProvider, useForm } from 'react-hook-form';
+import { Link, useNavigate } from 'react-router-dom';
+import { LoginValues, loginSchema } from '@/lib/schemas/loginSchema';
+
 import Card from '@/components/common/card/Card';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { loginSchema, LoginValues } from '@/lib/schemas/loginSchema';
 import LoginSection from '@/components/login/LoginSection';
-import usePostSignin from '@/lib/apis/mutations/usePostSignin';
+import styles from './page.module.scss';
+import { useAuth } from '@/lib/hooks/useAuth';
+import { zodResolver } from '@hookform/resolvers/zod';
 
 const defaultValues = {
   email: '',
@@ -14,18 +15,19 @@ const defaultValues = {
 
 export default function LoginPage() {
   const navigate = useNavigate();
-  const { mutate, error, isPending, isError } = usePostSignin();
   const formState = useForm({
     defaultValues,
     resolver: zodResolver(loginSchema),
   });
 
-  const onSubmit = (data: LoginValues) => {
-    mutate(data);
-    console.log(`로그인 시도: ${data.email} Error: ${error}`);
+  const { loginAndFetchUser } = useAuth();
 
-    if (!isError) {
+  const onSubmit = async (data: LoginValues) => {
+    try {
+      await loginAndFetchUser(data);
       navigate('/');
+    } catch (err) {
+      console.error('로그인 실패:', err);
     }
   };
 
@@ -44,7 +46,7 @@ export default function LoginPage() {
         <Card>
           <FormProvider {...formState}>
             <form onSubmit={formState.handleSubmit(onSubmit, onError)}>
-              <LoginSection isPending={isPending} />
+              <LoginSection isPending={formState.formState.isSubmitting} />
             </form>
           </FormProvider>
         </Card>

--- a/src/pages/register/Page.tsx
+++ b/src/pages/register/Page.tsx
@@ -1,16 +1,18 @@
-import Card from '@/components/common/card/Card';
-import styles from './page.module.scss';
+import { FormProvider, useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
-import { useState } from 'react';
-import Progress from '@/components/common/progress/Progress';
+import { RegisterValues, registerSchema } from '@/lib/schemas/registerSchema';
+
+import Card from '@/components/common/card/Card';
 import FirstSection from '@/components/register/FirstSection';
+import FourthSection from '@/components/register/FourthSection';
+import Progress from '@/components/common/progress/Progress';
 import SecondSection from '@/components/register/SecondSection';
 import ThirdSection from '@/components/register/ThirdSections';
-import FourthSection from '@/components/register/FourthSection';
-import { FormProvider, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { registerSchema, RegisterValues } from '@/lib/schemas/registerSchema';
+import { profile } from 'console';
+import styles from './page.module.scss';
 import usePostForeignerSignup from '@/lib/apis/mutations/usePoseForeignerSignup';
+import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
 
 const defaultValues = {
   email: '',
@@ -24,6 +26,7 @@ const defaultValues = {
   address: '',
   detailAddress: '',
   zipcode: '',
+  profileImageUrl: 'default',
 };
 
 export default function RegisterPage() {


### PR DESCRIPTION
## 📌 관련 이슈

> 관련 이슈번호를 작성해주세요.
#73

## ✨ PR 세부 내용

> 해당 PR에서 작업한 내용을 설명해주세요.
- 구현된 fetcher를 사용하여 로그인 api 연결하는 코드를 작성했습니다.
- 구현된 fetcher를 사용하여 외국인 사용자 회원가입 api를 연결하는 코드를 작성했습니다.
- 회원가입 시 기업 사용자인지 체크할 수 있는 버튼을 추가하였습니다.
- 로그인 후 헤더를 조건부 렌더링으로 변경하였습니다.
- 로그인 후 사용자 정보를 불러와 zustand로 상태관리 하도록 store 코드를 작성하였습니다.
- 로그인 후 사용자 정보를 zustand로 관리하는 부분을 커스텀 훅(useAuth.ts)로 관리하였습니다.



## 📸 스크린샷 (선택)
<img width="1359" height="747" alt="image" src="https://github.com/user-attachments/assets/28eccdf5-0c5b-4884-bdad-9ec4ee3321ee" />

<img width="862" height="546" alt="image" src="https://github.com/user-attachments/assets/1446f9d9-4e5a-4214-b0d1-b693e7fb8613" />


> UI 변경사항이 있다면 작성해주세요. 작성하지 않을 경우 지워주세요.

## ✅ 리뷰 요구사항 (선택)

> 기업 사용자 회원가입은 현재 백엔드 측에서 로직 관련 변동사항이 있을 예정이라 구현을 마무리하지 않았습니다. 
실제로 "기업 사용자입니까 ?"를 체크하여 회원가입을 진행할 경우 기업 사용자 회원가입 api에 요청을 보내지만, 요청 인자가 맞지 않아 오류가 발생합니다. 추후에 백엔드 로직에 맞게 수정이 필요합니다.


