### PR TITLE
feat: 프로필 관리 페이지 api 연결 및 목록 수정

### DIFF
--- a/src/components/profile/ApplicationHistory.tsx
+++ b/src/components/profile/ApplicationHistory.tsx
@@ -8,11 +8,13 @@ interface ApplicationHistoryProps {
 }
 
 export function ApplicationHistory({ applications }: ApplicationHistoryProps) {
+  const recentApplications = [...applications].slice(0, 3);
+
   return (
     <div className={styles.container}>
       <ApplicationHistory.Header count={applications.length} />
       <ApplicationHistory.List>
-        {applications.map(application => (
+        {recentApplications.map(application => (
           <ApplicationHistory.Item
             key={application.id}
             application={application}

--- a/src/components/profile/ProfileBottom.tsx
+++ b/src/components/profile/ProfileBottom.tsx
@@ -23,7 +23,7 @@ export default function ProfileBottom({ resumes, applications }: Props) {
         <p className={styles.statsItemValue}>{applications.length}</p>
       </div>
       <div>
-        <p className={styles.statsItemLabel}>이력서</p>
+        <p className={styles.statsItemLabel}>관심 기업</p>
         <p className={styles.statsItemValue}>{resumes.length}</p>
       </div>
     </div>

--- a/src/components/profile/ResumeList.tsx
+++ b/src/components/profile/ResumeList.tsx
@@ -32,43 +32,47 @@ export default function ResumeList({ resumes, children }: Props) {
   );
 }
 
-ResumeList.items = ({ resumes }: Omit<Props, 'children'>) => (
-  <div className={styles.resumeItems}>
-    {resumes.map(resume => (
-      <div key={resume.id} className={styles.resumeItem}>
-        <div className={styles.resumeInfo}>
-          <div className={styles.icon}>
-            <FileText />
+ResumeList.items = ({ resumes }: Omit<Props, 'children'>) => {
+  const sortedResumes = [...resumes];
+
+  return (
+    <div className={styles.resumeItems}>
+      {sortedResumes.slice(0, 3).map(resume => (
+        <div key={resume.id} className={styles.resumeItem}>
+          <div className={styles.resumeInfo}>
+            <div className={styles.icon}>
+              <FileText />
+            </div>
+            <div className={styles.text}>
+              <h3>{resume.title}</h3>
+              <p>최종 수정일: {resume.updatedAt.slice(0, 10)}</p>
+            </div>
           </div>
-          <div className={styles.text}>
-            <h3>{resume.title}</h3>
-            <p>최종 수정일: {resume.updatedAt}</p>
+          <div className={styles.actions}>
+            <span
+              className={clsx(
+                styles.status,
+                resume.status === '작성완료'
+                  ? styles.completed
+                  : styles.inProgress,
+              )}
+            >
+              {resume.status}
+            </span>
+            <div className={styles.iconButtons}>
+              <button className={styles.iconButton}>
+                <Eye />
+              </button>
+              <button className={styles.iconButton}>
+                <PenSquare />
+              </button>
+              <button className={styles.iconButton}>
+                <Trash2 />
+              </button>
+            </div>
           </div>
         </div>
-        <div className={styles.actions}>
-          <span
-            className={clsx(
-              styles.status,
-              resume.status === '작성완료'
-                ? styles.completed
-                : styles.inProgress,
-            )}
-          >
-            {resume.status}
-          </span>
-          <div className={styles.iconButtons}>
-            <button className={styles.iconButton}>
-              <Eye />
-            </button>
-            <button className={styles.iconButton}>
-              <PenSquare />
-            </button>
-            <button className={styles.iconButton}>
-              <Trash2 />
-            </button>
-          </div>
-        </div>
-      </div>
-    ))}
-  </div>
-);
+      ))}
+    </div>
+  );
+};

--- a/src/components/profile/resume/create/BasicInfo.tsx
+++ b/src/components/profile/resume/create/BasicInfo.tsx
@@ -19,6 +19,7 @@ export default function BasicInfo() {
   const name = useAuthStore(state => state.name);
   const email = useAuthStore(state => state.email);
   const phoneNumber = useAuthStore(state => state.phoneNumber);
+  const address = useAuthStore(state => state.address);
   const profileImageUrl = useAuthStore(state => state.profileImageUrl);
 
   const image = uploadedImage || profileImageUrl;
@@ -52,12 +53,14 @@ export default function BasicInfo() {
             <label className={styles.label}>전화번호</label>
             <div className={styles.readonlyInput}>{phoneNumber}</div>
           </div>
-          <InputField
-            control={control}
-            name='address'
-            label='주소'
-            required={true}
-          />
+          <div className={styles.readonlyField}>
+            <label className={styles.label}>주소</label>
+            <div className={styles.readonlyInput}>
+              {address.address}
+              {address.detailAddress && ` ${address.detailAddress}`}
+              {address.zipcode && ` (${address.zipcode})`}
+            </div>
+          </div>
         </div>
         <div className={styles.imageRow}>
           <div className={styles.imageWrapper}>

--- a/src/components/profile/resume/create/BottomActions.tsx
+++ b/src/components/profile/resume/create/BottomActions.tsx
@@ -23,7 +23,6 @@ export default function BottomActions() {
   const progress = useMemo(() => {
     const requiredFields = [
       'resumeTitle',
-      'address',
       'desiredJobs',
       'skills',
       'jobPreference.desiredEmploymentType',

--- a/src/pages/profile/Page.tsx
+++ b/src/pages/profile/Page.tsx
@@ -1,40 +1,29 @@
 import { UserProfile, ResumeList } from '@/components/profile';
-
-import styles from './page.module.scss';
 import { ApplicationHistory } from '@/components/profile/ApplicationHistory';
+import styles from './page.module.scss';
 import { ChevronRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { useAuthStore } from '@/lib/stores/useAuthStore';
+import useGetResumeList from '@/lib/apis/queries/useGetResumeList';
 
-const userInfo = {
-  profileImageUrl: 'https://randomuser.me/api',
-  name: '홍길동',
-  email: 'dswvgw1234@gmail.com',
-  phoneNumber: '010-1234-5678',
-  region: '서울특별시 강남구',
-  resumes: [
-    {
-      id: 1,
-      title: '이력서1',
-      status: '작성완료',
-      createdAt: '2021-08-01',
-      updatedAt: '2021-08-01',
-    },
-    {
-      id: 2,
-      title: '이력서2',
-      status: '작성중',
-      createdAt: '2021-08-01',
-      updatedAt: '2021-08-01',
-    },
-    {
-      id: 3,
-      title: '이력서3',
-      status: '작성완료',
-      createdAt: '2021-08-01',
-      updatedAt: '2021-08-01',
-    },
-  ],
-  applications: [
+export default function ProfilePage() {
+  const name = useAuthStore(state => state.name);
+  const email = useAuthStore(state => state.email);
+  const phoneNumber = useAuthStore(state => state.phoneNumber);
+  const profileImageUrl = useAuthStore(state => state.profileImageUrl);
+  const address = useAuthStore(state => state.address);
+
+  const { data, isLoading } = useGetResumeList();
+
+  const resumes = (data?.data.content || []).map(item => ({
+    id: item.resumeId,
+    title: item.resumeTitle,
+    status: '작성완료',
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  }));
+
+  const applications = [
     {
       id: 1,
       company: '토스',
@@ -56,15 +45,24 @@ const userInfo = {
       appliedAt: '2021-08-01',
       status: '탈락',
     },
-  ],
-};
+  ];
 
-export default function ProfilePage() {
+  const userInfo = {
+    name,
+    email,
+    phoneNumber,
+    profileImageUrl,
+    region: address.address,
+    resumes,
+    applications,
+  };
+
   return (
     <div className={styles.container}>
       <main className={styles.page}>
         <h1>프로필</h1>
         <UserProfile userInfo={userInfo} />
+
         <section>
           <div className={styles.sectionHeader}>
             <h2>내 이력서</h2>
@@ -73,10 +71,16 @@ export default function ProfilePage() {
               <ChevronRight />
             </Link>
           </div>
-          <ResumeList resumes={userInfo.resumes}>
-            <ResumeList.items resumes={userInfo.resumes} />
-          </ResumeList>
+
+          {isLoading ? (
+            <p>불러오는 중...</p>
+          ) : (
+            <ResumeList resumes={resumes}>
+              <ResumeList.items resumes={resumes} />
+            </ResumeList>
+          )}
         </section>
+
         <section>
           <div className={styles.sectionHeader}>
             <h2>지원 내역</h2>
@@ -88,7 +92,7 @@ export default function ProfilePage() {
               <ChevronRight />
             </Link>
           </div>
-          <ApplicationHistory applications={userInfo.applications} />
+          <ApplicationHistory applications={applications} />
         </section>
       </main>
     </div>


### PR DESCRIPTION
## 📌 관련 이슈

> 관련 이슈번호를 작성해주세요..
#74 

## ✨ PR 세부 내용

> 해당 PR에서 작업한 내용을 설명해주세요.
- 유저 주소 정보를 이력서 내용에 반영했습니다.
- 프로필 관리 페이지에 유저 정보를 상태 관리를 통해 불러왔습니다.
- 내 이력서 리스트, 지원 내역 리스트를 최대 3개까지 표시하게 수정했습니다.
- 내 이력서 리스트를 api와 연결했습니다.

## 📸 스크린샷 (선택)

> UI 변경사항이 있다면 작성해주세요. 작성하지 않을 경우 지워주세요.
<img width="751" height="1086" alt="image" src="https://github.com/user-attachments/assets/0b58ed5e-a1f5-4c33-a269-cc079a9835bf" />


## ✅ 리뷰 요구사항 (선택)

> 리뷰어가 신경써서 리뷰할 내용이 있다면 작성해주세요.  
- 지원 내역 관련 api가 아직 존재하지 않아 api 연결이 되지 않았습니다.
