### PR TITLE
[FIX] 이메일 인증 폼 개선

### DIFF
--- a/src/components/verifyEmail/VerifyCodeInputField.tsx
+++ b/src/components/verifyEmail/VerifyCodeInputField.tsx
@@ -46,9 +46,8 @@ export default function VerifyCodeInputField({
     field: ControllerRenderProps<FieldValues, string>,
   ) => {
     const target = e.currentTarget;
-    const onlyNumber = formatOnlyNumber(target.value);
-    target.value = onlyNumber.slice(0, 1);
-    field.onChange(target.value);
+    const nextValue = formatOnlyNumber(target.value).slice(0, 1);
+    field.onChange(nextValue);
 
     const isFilled = names.every(name => getValues(name));
 
@@ -56,7 +55,7 @@ export default function VerifyCodeInputField({
       submitButtonRef?.current?.click();
     }
 
-    if (target.value && idx < names.length - 1) {
+    if (nextValue && idx < names.length - 1) {
       focusIndex(idx + 1);
     }
   };
@@ -136,7 +135,9 @@ export default function VerifyCodeInputField({
             name={name}
             render={({ field }) => (
               <input
+                {...field}
                 ref={el => {
+                  field.ref(el);
                   if (el) inputsRef.current[idx] = el;
                 }}
                 className={styles.input}
@@ -145,6 +146,7 @@ export default function VerifyCodeInputField({
                 autoComplete='one-time-code'
                 pattern='[0-9]?'
                 maxLength={1}
+                value={(field.value as string) ?? ''}
                 onChange={e => handleChange(idx, e, field)}
                 onKeyDown={e => handleKeyDown(e, idx)}
                 onPaste={e => handlePaste(e, 0)}

--- a/src/components/verifyEmail/VerifyCodeInputField.tsx
+++ b/src/components/verifyEmail/VerifyCodeInputField.tsx
@@ -16,7 +16,7 @@ interface VerifyCodeInputFieldProps {
 export default function VerifyCodeInputField({
   submitButtonRef,
 }: VerifyCodeInputFieldProps) {
-  const { setValue, getValues, watch } = useFormContext();
+  const { setValue, getValues } = useFormContext();
 
   const names = useMemo(() => ['1', '2', '3', '4', '5', '6'] as const, []);
   const inputsRef = useRef<HTMLInputElement[]>([]);
@@ -65,11 +65,10 @@ export default function VerifyCodeInputField({
     }
 
     if (key === 'Backspace') {
-      const current = (getValues(names[idx]) as string) ?? '';
+      const length = inputsRef.current[idx]?.value.length;
 
-      if (!current && idx > 0) {
+      if (length === 0 && idx > 0) {
         e.preventDefault();
-        setValue(names[idx - 1], '');
         focusIndex(idx - 1);
       }
 
@@ -117,9 +116,6 @@ export default function VerifyCodeInputField({
     focusIndex(next);
   };
 
-  // watch 값으로 리렌더링 유도
-  watch(names);
-
   return (
     <div className={styles.container}>
       {names.map((name, idx) => (
@@ -132,9 +128,8 @@ export default function VerifyCodeInputField({
             type='text'
             inputMode='numeric'
             autoComplete='one-time-code'
-            pattern='[0-9]*'
+            pattern='[0-9]?'
             maxLength={1}
-            value={(getValues(name) as string) ?? ''}
             onChange={e => handleChange(idx, e.target.value)}
             onKeyDown={e => handleKeyDown(e, idx)}
             onPaste={e => handlePaste(e, 0)}

--- a/src/components/verifyEmail/VerifyCodeInputField.tsx
+++ b/src/components/verifyEmail/VerifyCodeInputField.tsx
@@ -65,13 +65,6 @@ export default function VerifyCodeInputField({
     idx: number,
   ) => {
     const key = e.key;
-    const isCtrlMeta =
-      (e.ctrlKey || e.metaKey) &&
-      ['a', 'c', 'v', 'x'].includes(e.key.toLowerCase());
-
-    if (isCtrlMeta) {
-      return;
-    }
 
     if (key === 'Backspace') {
       const length = inputsRef.current[idx]?.value.length ?? 0;

--- a/src/components/verifyEmail/VerifyCodeInputField.tsx
+++ b/src/components/verifyEmail/VerifyCodeInputField.tsx
@@ -68,7 +68,6 @@ export default function VerifyCodeInputField({
     const isCtrlMeta =
       (e.ctrlKey || e.metaKey) &&
       ['a', 'c', 'v', 'x'].includes(e.key.toLowerCase());
-    const isNoneNumeric = !/^[0-9]$/.test(key) && key.length === 1;
 
     if (isCtrlMeta) {
       return;
@@ -95,11 +94,6 @@ export default function VerifyCodeInputField({
       e.preventDefault();
       focusIndex(Math.min(names.length - 1, idx + 1));
       return;
-    }
-
-    // 숫자 외 입력 방지
-    if (isNoneNumeric) {
-      e.preventDefault();
     }
   };
 

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -14,3 +14,7 @@ export const formatPhoneNumber = (value: string) => {
     .replace(NUMBER_ONLY_REGEX, '')
     .replace(PHONE_NUMBER_FORMAT_REGEX, formatToHyphenatedNumber);
 };
+
+export const formatOnlyNumber = (value: string) => {
+  return value.replace(NUMBER_ONLY_REGEX, '');
+};


### PR DESCRIPTION
## 📌 관련 이슈

#104 

## ✨ PR 세부 내용

### 불필요한 리렌더링 방지

기존에 구현했던 FormField 컴포넌트를 활용하여 특정 input 태그 변경 시 폼 전체가 리렌더링 되는 현상을 개선

```tsx
<FormField
  control={control}
  name={name}
  render={({ field }) => (
    <input
      {...field}
      ref={el => {
        field.ref(el);
        if (el) inputsRef.current[idx] = el;
      }}
      className={styles.input}
      type='text'
      inputMode='numeric'
      autoComplete='one-time-code'
      pattern='[0-9]?'
      maxLength={1}
      value={(field.value as string) ?? ''}
      onChange={e => handleChange(idx, e, field)}
      onKeyDown={e => handleKeyDown(e, idx)}
      onPaste={e => handlePaste(e, 0)}
      aria-label={`인증 코드 ${idx + 1}번째 숫자`}
    />
  )}
/>
```
